### PR TITLE
adds quotes around column name

### DIFF
--- a/src/ModelSearchAspect.php
+++ b/src/ModelSearchAspect.php
@@ -108,7 +108,7 @@ class ModelSearchAspect extends SearchAspect
         $query->where(function (Builder $query) use ($attributes, $term, $searchTerms) {
             foreach (Arr::wrap($attributes) as $attribute) {
                 foreach ($searchTerms as $searchTerm) {
-                    $sql = "LOWER({$attribute->getAttribute()}) LIKE ?";
+                    $sql = "LOWER(\"{$attribute->getAttribute()}\") LIKE ?";
                     $searchTerm = mb_strtolower($searchTerm, 'UTF8');
 
                     $attribute->isPartial()


### PR DESCRIPTION
currently query will throw exception if column name is a SQL keyword. for example if we have "to" as column name it will throw:
SQLSTATE[HY000]: General error: 1 near "to": syntax error (SQL: select * from "redirects" where (LOWER(to) LIKE %gi%))

we simply add quotes around column name to solve it.